### PR TITLE
feat: moderniza README de perfil com posicionamento sênior e métricas

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,12 @@
 <div align="center">
 
-# 👋 Olá, sou Sthevan Santos
+# 👋 Olá, eu sou Sthevan Santos
 
-**Engenheiro de Software | Dev FullStack**  
-Frontend • Python | React | TypeScript | MongoDB
+### Engenheiro de Software Full Stack • Founder @ Virex
+
+<p>
+  <img src="https://readme-typing-svg.herokuapp.com?font=Inter&weight=600&size=22&duration=3200&pause=900&color=2F81F7&center=true&vCenter=true&width=700&lines=Construindo+sistemas+que+viram+resultado;Arquitetura+limpa%2C+c%C3%B3digo+manuten%C3%ADvel+e+foco+no+neg%C3%B3cio;Frontend+e+Backend+com+vis%C3%A3o+de+produto" alt="Typing SVG" />
+</p>
 
 [![GitHub followers](https://img.shields.io/github/followers/sthevan027?style=social)](https://github.com/sthevan027)
 [![LinkedIn](https://img.shields.io/badge/LinkedIn-sthevan--santos-0A66C2?style=flat&logo=linkedin)](https://www.linkedin.com/in/sthevan-santos/)
@@ -13,43 +16,66 @@ Frontend • Python | React | TypeScript | MongoDB
 
 ---
 
-Desenvolvedor Web com foco em **sistemas de gestão**, **aplicações web** e **automações**.  
-Atuo no desenvolvimento **frontend e backend**, com forte entendimento de **regras de negócio** e construção de soluções práticas para empresas.
+## 👨‍💼 Perfil profissional
 
-Sou fundador da **Virex**, onde participo diretamente do desenvolvimento técnico dos projetos, desde o levantamento de requisitos até a entrega e manutenção dos sistemas.
+Sou desenvolvedor com atuação ponta a ponta em produtos digitais, com foco em **sistemas de gestão**, **aplicações web de alto impacto** e **automações de processos**.
+
+Como fundador da **Virex**, participo desde a estratégia técnica e modelagem de solução até a entrega em produção e evolução contínua, sempre equilibrando:
+
+- **Qualidade técnica** (arquitetura, legibilidade e escalabilidade);
+- **Velocidade de entrega** com previsibilidade;
+- **Valor de negócio** orientado por resultado.
 
 ---
 
-## 💻 Stack Tecnológica
+## 🧠 Stack principal
 
-### Linguagens
+### Linguagens e ecossistema
+
 ![JavaScript](https://img.shields.io/badge/JavaScript-F7DF1E?style=flat&logo=javascript&logoColor=000)
 ![TypeScript](https://img.shields.io/badge/TypeScript-3178C6?style=flat&logo=typescript&logoColor=fff)
 ![Python](https://img.shields.io/badge/Python-3776AB?style=flat&logo=python&logoColor=fff)
 ![HTML5](https://img.shields.io/badge/HTML5-E34F26?style=flat&logo=html5&logoColor=fff)
 ![CSS3](https://img.shields.io/badge/CSS3-1572B6?style=flat&logo=css3&logoColor=fff)
+![React](https://img.shields.io/badge/React-20232A?style=flat&logo=react&logoColor=61DAFB)
+![Node.js](https://img.shields.io/badge/Node.js-339933?style=flat&logo=nodedotjs&logoColor=fff)
+![MongoDB](https://img.shields.io/badge/MongoDB-47A248?style=flat&logo=mongodb&logoColor=fff)
 
 ---
 
-## 🚀 O que eu construo
+## 🚀 O que eu entrego
 
-| Área | Descrição |
-|------|-----------|
-| 🏢 **Gestão** | Sistemas de gestão interna |
-| 📊 **Dashboards** | Painéis administrativos |
-| ⚙️ **Automações** | Automação de processos |
-| 🌐 **Web** | Aplicações sob medida |
-| 🔗 **Integrações** | Integração entre sistemas |
+| Área                         | Entregas                                                             |
+| ---------------------------- | -------------------------------------------------------------------- |
+| 🏢 **Sistemas de Gestão**    | ERPs internos, controle operacional e processos corporativos         |
+| 📊 **Dashboards Executivos** | Indicadores, BI operacional e tomada de decisão orientada a dados    |
+| ⚙️ **Automações**            | Eliminação de tarefas repetitivas e ganho real de produtividade      |
+| 🌐 **Aplicações Web**        | Produtos sob medida com foco em performance e experiência do usuário |
+| 🔗 **Integrações**           | APIs, sincronização de dados e orquestração entre plataformas        |
 
 ---
 
-## 📫 Contato
+## 📈 Métricas de código e consistência
+
+<div align="center">
+
+<img height="170" src="https://github-readme-stats.vercel.app/api?username=sthevan027&show_icons=true&theme=tokyonight&hide_border=true&count_private=true" alt="GitHub stats" />
+<img height="170" src="https://streak-stats.demolab.com?user=sthevan027&theme=tokyonight&hide_border=true" alt="GitHub streak" />
+
+<img height="170" src="https://github-readme-stats.vercel.app/api/top-langs/?username=sthevan027&layout=compact&theme=tokyonight&hide_border=true" alt="Top languages" />
+
+</div>
+
+---
+
+## 🤝 Vamos conectar
 
 [![WhatsApp](https://img.shields.io/badge/WhatsApp-Fale%20comigo-25D366?style=for-the-badge&logo=whatsapp)](https://wa.me/5527988772784?text=Oi%2C%20queria%20conhecer%20mais%20sobre%20seus%20projetos)
 [![LinkedIn](https://img.shields.io/badge/LinkedIn-sthevan--santos-0A66C2?style=for-the-badge&logo=linkedin)](https://www.linkedin.com/in/sthevan-santos/)
 [![Email](https://img.shields.io/badge/Email-sthevan.ssantos%40gmail.com-EA4335?style=for-the-badge&logo=gmail)](mailto:sthevan.ssantos@gmail.com)
 
 ---
+
 <div align="center">
   <img src="https://komarev.com/ghpvc/?username=sthevan027&color=blueviolet&style=flat-square" alt="Profile views" />
 </div>


### PR DESCRIPTION
### Motivation
- Atualizar o `README.md` do perfil para transmitir um posicionamento sênior, mais personalizado e orientado a resultado.
- Destacar métricas de atividade e linguagens para evidenciar consistência técnica e presença ativa no GitHub.
- Melhorar clareza da apresentação técnica (stack e entregas) sem tocar em código funcional do projeto.

### Description
- Reestruturei o cabeçalho e a introdução com headline profissional, banner de typing e mensagem de valor para um tom mais sênior.
- Ampliei a seção de stack com badges adicionais (`React`, `Node.js`, `MongoDB`) e reorganizei a lista de tecnologias.
- Substituí a seção de "o que eu construo" por uma tabela de entregas mais executiva e adicionei cards de métricas (`github-readme-stats`, streak e `top-langs`).
- Apliquei formatação consistente com `Prettier` e a mudança afetou apenas o arquivo `README.md`.

### Testing
- Rodei `npx --yes prettier --check README.md` e o check falhou inicialmente por issues de estilo. 
- Corrigi a formatação com `npx --yes prettier --write README.md` e revalidei com `npx --yes prettier --check README.md`, que passou sem erros. 
- Executei `git diff --check` como verificação de limpeza de diff e não foram reportados problemas.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b5ad4837bc8328bbb4cce4a187d846)